### PR TITLE
CF: Specify gitbook version to allow plugin features

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,4 +1,5 @@
 {
+  "gitbook": "2.6.x",
   "plugins": [
     "-sharing",
     {


### PR DESCRIPTION
It appears the issue with plugins is related to older versions of gitbook that don't support some of the plugin features.  This book.json file now specifies the version number which will force the install of the new gitbook version when a "gitbook build" or "gitbook serve" is called.