### PR TITLE
Update Download links

### DIFF
--- a/de/book.json
+++ b/de/book.json
@@ -18,7 +18,7 @@
 				{            
 					"label": "Download",
 					"icon": "fa fa-file-pdf-o fa-lg",
-					"url": "https://primer.dynamobim.org/en/Appendix/DynamoPrimer-Print.pdf"
+					"url": "https://primer.dynamobim.org/de/Appendix/DynamoPrimer-Print.pdf"
 				}],
 			"languages":[
 				 {

--- a/ja/book.json
+++ b/ja/book.json
@@ -18,7 +18,7 @@
 				{            
 					"label": "Download",
 					"icon": "fa fa-file-pdf-o fa-lg",
-					"url": "https://primer.dynamobim.org/en/Appendix/DynamoPrimer-Print.pdf"
+					"url": "https://primer.dynamobim.org/ja/Appendix/DynamoPrimer-Print.pdf"
 				}],
 			"languages":[
 				 {

--- a/zh-tw/book.json
+++ b/zh-tw/book.json
@@ -18,7 +18,7 @@
 				{            
 					"label": "Download",
 					"icon": "fa fa-file-pdf-o fa-lg",
-					"url": "https://primer.dynamobim.org/en/Appendix/DynamoPrimer-Print.pdf"
+					"url": "https://primer.dynamobim.org/zh-tw/Appendix/DynamoPrimer-Print.pdf"
 				}],
 			"languages":[
 				 {


### PR DESCRIPTION
Looks like a regression from  https://github.com/DynamoDS/DynamoPrimer/pull/125, I am not exactly sure how staging is correctly but prod are not. It has been too long.

Anyway, the bug is that downloading pdfs from all other languages all pointing to `en`.