### PR TITLE
Dyn 2773 dynamo primer white source

### DIFF
--- a/DockerUtilities/CopyLibrariesToHostScript.ps1
+++ b/DockerUtilities/CopyLibrariesToHostScript.ps1
@@ -1,0 +1,86 @@
+
+<#This powershell script will copy the third party libraries described below from the DynamoPrimer container to the host computer.
+- Calibre v3.48 - ebook-convert
+- Ghostscript 9.50 (gs)
+- AWS Powershell Modules
+- Node.js v6.17 x64 (npm -> node_modules -> gitbook) 
+- Vault Libraries
+#>
+
+#This variables need to be set up before stoping the container (because are env variables inside the container)
+$appData= docker exec build-primer cmd /C echo "%APPDATA%"
+$documentsFolder = docker exec build-primer pwsh -Command "[Environment]::GetFolderPath('MyDocuments')"
+$programFiles = docker exec build-primer cmd /C echo "%PROGRAMFILES%"
+$workFolder = $env:WORKSPACE
+$gitbookFolders = @(docker exec build-primer pwsh -Command "Get-ChildItem -Directory -Path $appData\npm\node_modules\gitbook-cli  | Select FullName -ExpandProperty FullName")
+$gitbookNodeModulesFolders = @(docker exec build-primer pwsh -Command "Get-ChildItem -Directory -Path $appData\npm\node_modules\gitbook-cli\node_modules | Select FullName -ExpandProperty FullName")
+#Check if container is running, then stop it
+if (docker inspect -f "{{.State.Running}}" build-primer ) 
+{
+    docker stop build-primer
+}
+
+#Create the paths to the libraries folders
+$ghostScriptLibraries = Join-Path -Path $programFiles -ChildPath "gs\gs9.50"
+$calibreLibraries = Join-Path -Path $programFiles -ChildPath "Calibre2"
+$vaultLibraries = "C:\Vault"
+$PSAWSLibraries = Join-Path -Path $documentsFolder -ChildPath "PowerShell\Modules"
+
+#Creates an String array with all the library paths created previously (CONSIDER THAT THE NODEJS LIBRARIES IS NOT INCLUDED)
+$LibrariesArray = @($ghostScriptLibraries, $calibreLibraries, $vaultLibraries, $PSAWSLibraries)
+$librariesFolderPath = Join-Path -Path $workFolder -ChildPath $env:LIBRARIES_FOLDER
+
+#Create a new folder named "$FolderName" in the specified path "$Path", if the folder already exist it will just send a message
+Function CreateNewFolder([string]$Path, [string]$FolderName) {
+    $fullPath = Join-Path -Path $Path -ChildPath $FolderName
+    if (-not (Test-Path -LiteralPath $fullPath)) {  
+        try {
+            #This will create a libraries folder in which all the third party libraries will be copied
+            New-Item -Path $Path -Name $FolderName  -ItemType "directory"
+            Write-Host "New Folder Created: $fullPath"
+        }
+        catch {
+            Write-Host -Message "Unable to create directory '$FolderName'. Error was: $_" -ErrorAction Stop
+        }
+    }
+    else {
+        Write-Host -Message "Directory already existed"
+    }
+}
+
+#Create the folder in which will copy the third_party_libraries
+CreateNewFolder $workFolder $env:LIBRARIES_FOLDER
+#This folder is where the gitbook-cli subfolders will be copied
+CreateNewFolder $workFolder $env:LIBRARIES_FOLDER\"gitbook-cli"
+
+#Check if the folder WSThirdPartyLibraries already exists, then proceed to copy the libraries
+if (Test-Path -LiteralPath $librariesFolderPath ) { 
+#Copy the folder path (in the array) from the container to the host
+    Foreach ($library in $LibrariesArray)
+    {
+        docker cp build-primer:$library $librariesFolderPath
+        Write-Host "Library copied: $library"
+    }
+}
+
+#This section will copy each subfolder in the gitbook-cli folder 
+Foreach ($subFolder in $gitbookFolders)
+{
+    #gitbook-cli subfolders
+    Write-Host "Library folder copied: $subFolder"
+    docker cp build-primer:$subFolder $librariesFolderPath\"gitbook-cli"
+}
+
+#Copy the each subfolder from the node_modules folder (due that npm folder has large nested subfolders that makes the docker cp crash
+Foreach ($subFolder in $gitbookNodeModulesFolders)
+{
+    #The npm folder has a very large nested subfolders that make the docker cp command crash
+    if ( -not ($subFolder -match "\\npm$"))
+    {
+        #gitbook-cli\node_modules subfolders
+        Write-Host "Library folder copied: $subFolder"
+        docker cp build-primer:$subFolder $librariesFolderPath\"gitbook-cli\node_modules"
+    } 
+}
+
+docker start build-primer

--- a/DockerUtilities/CopyLibrariesToHostScript.ps1
+++ b/DockerUtilities/CopyLibrariesToHostScript.ps1
@@ -7,7 +7,7 @@
 - Vault Libraries
 #>
 
-#This variables need to be set up before stoping the container (because are env variables inside the container)
+#The container env variables need to be fetch and store them in powershell variables before stoping the container (They are system env variables already created inside the docker container)
 $appData= docker exec build-primer cmd /C echo "%APPDATA%"
 $documentsFolder = docker exec build-primer pwsh -Command "[Environment]::GetFolderPath('MyDocuments')"
 $programFiles = docker exec build-primer cmd /C echo "%PROGRAMFILES%"
@@ -26,11 +26,11 @@ $calibreLibraries = Join-Path -Path $programFiles -ChildPath "Calibre2"
 $vaultLibraries = "C:\Vault"
 $PSAWSLibraries = Join-Path -Path $documentsFolder -ChildPath "PowerShell\Modules"
 
-#Creates an String array with all the library paths created previously (CONSIDER THAT THE NODEJS LIBRARIES IS NOT INCLUDED)
+#Creates an String array with all the library paths created previously (CONSIDER THAT THE NODEJS LIBRARIES ARE NOT INCLUDED)
 $LibrariesArray = @($ghostScriptLibraries, $calibreLibraries, $vaultLibraries, $PSAWSLibraries)
 $librariesFolderPath = Join-Path -Path $workFolder -ChildPath $env:LIBRARIES_FOLDER
 
-#Create a new folder named "$FolderName" in the specified path "$Path", if the folder already exist it will just send a message
+#Create a new folder named "$FolderName" in the specified path "$Path", if the folder already exist will just send a message
 Function CreateNewFolder([string]$Path, [string]$FolderName) {
     $fullPath = Join-Path -Path $Path -ChildPath $FolderName
     if (-not (Test-Path -LiteralPath $fullPath)) {  
@@ -55,7 +55,7 @@ CreateNewFolder $workFolder $env:LIBRARIES_FOLDER\"gitbook-cli"
 
 #Check if the folder WSThirdPartyLibraries already exists, then proceed to copy the libraries
 if (Test-Path -LiteralPath $librariesFolderPath ) { 
-#Copy the folder path (in the array) from the container to the host
+#Copy the folder path (in the array) content from the container to the host
     Foreach ($library in $LibrariesArray)
     {
         docker cp build-primer:$library $librariesFolderPath
@@ -63,7 +63,7 @@ if (Test-Path -LiteralPath $librariesFolderPath ) {
     }
 }
 
-#This section will copy each subfolder in the gitbook-cli folder 
+#This section will copy each subfolder (and it's contents) in the gitbook-cli folder 
 Foreach ($subFolder in $gitbookFolders)
 {
     #gitbook-cli subfolders
@@ -71,7 +71,7 @@ Foreach ($subFolder in $gitbookFolders)
     docker cp build-primer:$subFolder $librariesFolderPath\"gitbook-cli"
 }
 
-#Copy the each subfolder from the node_modules folder (due that npm folder has large nested subfolders that makes the docker cp crash
+#Copy the each subfolder from the node_modules folder (due that npm folder has large nested subfolders that makes the docker cp crash)
 Foreach ($subFolder in $gitbookNodeModulesFolders)
 {
     #The npm folder has a very large nested subfolders that make the docker cp command crash

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -11,6 +11,7 @@ env:
   - BUCKETNAME : "primer.dynamobim.org"
   - DISTRIBUTIONID : "E1L4E92B2OBQIF"
   - DOCKER_WORKSPACE : "C:\\WorkspacePrimer"
+  - LIBRARIES_FOLDER : "WSThirdPartyLibraries"
 
 timeout: 420
 check_changelog_updated_on_pr: false
@@ -31,6 +32,7 @@ build:
     scripts:
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\PreBuildScript.ps1"
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\BuildScript.ps1"
+      - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\CopyLibrariesToHostScript.ps1"
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\PostBuildScript.ps1"
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\DeployScript.ps1"
       - "pwsh.exe -ExecutionPolicy ByPass -File .\\DockerUtilities\\PostDeployScript.ps1"
@@ -38,3 +40,17 @@ build:
 code_analysis:
   sonarqube:
     skip: true
+soc2:
+  run_on_any_branch : true
+  white_source:    
+    skip: false
+    fail_on_audit_failure: true
+    team: Dynamo
+    project_name: "DynamoPrimer"
+    hidden_email_list: dynamo_ws_access
+  third_party_lib_paths:
+    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\gs9.50"
+    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Modules"
+    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\gitbook-cli"
+    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Calibre2"
+    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Vault"

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -49,8 +49,8 @@ soc2:
     project_name: "DynamoPrimer"
     hidden_email_list: dynamo_ws_access
   third_party_lib_paths:
-    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\gs9.50"
-    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Modules"
-    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\gitbook-cli"
-    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Calibre2"
-    - "%WORKSPACE%\\%LIBRARIES_FOLDER%\\Vault"
+    - "%LIBRARIES_FOLDER%\\gs9.50"
+    - "%LIBRARIES_FOLDER%\\Modules"
+    - "%LIBRARIES_FOLDER%\\gitbook-cli"
+    - "%LIBRARIES_FOLDER%\\Calibre2"
+    - "%LIBRARIES_FOLDER%\\Vault"


### PR DESCRIPTION
### Purpose

Enable White Source scanning for third party libraries used in the DynamoPrimer repository
https://jira.autodesk.com/browse/DYN-2773

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 
@alfredo-pozo 

### FYIs

@alfredo-pozo 
