### PR TITLE
Dyn 3117 fix docker cp

### DIFF
--- a/DockerUtilities/CopyLibrariesToHostScript.ps1
+++ b/DockerUtilities/CopyLibrariesToHostScript.ps1
@@ -17,7 +17,7 @@ $gitbookNodeModulesFolders = @(docker exec $env:DOCKER_CONTAINER pwsh -Command "
 #Check if container is running, then stop it
 if (docker inspect -f "{{.State.Running}}" $env:DOCKER_CONTAINER ) 
 {
-    docker stop $env:DOCKER_CONTAINER
+    docker stop ${env:DOCKER_CONTAINER}
 }
 
 #Create the paths to the libraries folders
@@ -64,7 +64,7 @@ if (Test-Path -LiteralPath $librariesFolderPath )
 #Copy the folder path (in the array) content from the container to the host
     Foreach ($library in $LibrariesArray)
     {
-        docker cp $env:DOCKER_CONTAINER:$library $librariesFolderPath
+        docker cp ${env:DOCKER_CONTAINER}:$library $librariesFolderPath
         Write-Host "Library copied: $library"
     }
 }
@@ -74,7 +74,7 @@ Foreach ($subFolder in $gitbookFolders)
 {
     #gitbook-cli subfolders
     Write-Host "Library folder copied: $subFolder"
-    docker cp $env:DOCKER_CONTAINER:$subFolder $librariesFolderPath\"gitbook-cli"
+    docker cp ${env:DOCKER_CONTAINER}:$subFolder $librariesFolderPath\"gitbook-cli"
 }
 
 #Copy the each subfolder from the node_modules folder (due that npm folder has large nested subfolders that makes the docker cp crash)
@@ -85,8 +85,8 @@ Foreach ($subFolder in $gitbookNodeModulesFolders)
     {
         #gitbook-cli\node_modules subfolders
         Write-Host "Library folder copied: $subFolder"
-        docker cp $env:DOCKER_CONTAINER:$subFolder $librariesFolderPath\"gitbook-cli\node_modules"
+        docker cp ${env:DOCKER_CONTAINER}:$subFolder $librariesFolderPath\"gitbook-cli\node_modules"
     } 
 }
 
-docker start $env:DOCKER_CONTAINER
+docker start ${env:DOCKER_CONTAINER}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -54,3 +54,5 @@ soc2:
       - "%LIBRARIES_FOLDER%\\gitbook-cli"
       - "%LIBRARIES_FOLDER%\\Calibre2"
       - "%LIBRARIES_FOLDER%\\Vault"
+schedule:
+  cron_schedule: "once_a_month"


### PR DESCRIPTION
### Purpose
The DynamoPrimer job was failing due that the docker cp command was not recognizing the container name stored in a env variable, then I updated all the places inside the CopyLibrariesToHostScript in which the docker cp command is using the env variable to correctly get the container name.

### Declarations
****
Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

@QilongTang 

### FYIs

@alfredo-pozo 
