### PR TITLE
Uploading legacy DynamoPrimer1_3 pdf

### DIFF
--- a/scripts/DockerDeployCommands.ps1
+++ b/scripts/DockerDeployCommands.ps1
@@ -107,6 +107,10 @@ try {
       }
    }
 
+   #Copy DynamoPrimer legacy PDF
+   Write-Host "Uploading Legacy DynamoPrimer1_3 pdf version" 
+   UploadS3Object -localPath "en/legacy/DynamoPrimer-Print1_3.pdf" -prefixWhitPath "en/Appendix/DynamoPrimer-Print1_3.pdf"
+
    #Invalidating current CDN content to refresh it
    $invalidationLong = [long](Get-Date -Format "yyyddMMHHmm")
    New-CFInvalidation -DistributionId $distributionID -InvalidationBatch_CallerReference $invalidationLong -Paths_Item "/*" -Paths_Quantity 1 -Region $AWSRegion


### PR DESCRIPTION
Adding the extra build step for always uploading legacy DynamoPrimer1_3 pdf so that it is always deployed and available for user to download. This is done so that we avoid user issue like https://github.com/DynamoDS/DynamoPrimer/issues/274 